### PR TITLE
Look in the active project for a UUID if it is not given.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,6 +75,27 @@ end
 
         clear_scratchspaces!(Base.UUID(su_uuid))
         @test !isdir(scratch_dir(su_uuid))
+
+        # UUID lookup for active project when running in Main
+        ## Activate a new empty project
+        old_project = Base.ACTIVE_PROJECT[]
+        project = joinpath(mktempdir(), "Project.toml")
+        Base.ACTIVE_PROJECT[] = project
+        @test (@__MODULE__) == Main
+        ## Project.toml without UUID
+        path = @get_scratch!("project-no-uuid")
+        @test isdir(path)
+        @test path == scratch_dir(global_uuid, "project-no-uuid")
+        ## Project.toml with UUID
+        project_uuid = "69386cca-e009-4a96-a0ae-829213699cfc"
+        open(project, "w") do io
+            println(io, "uuid = \"$(project_uuid)\"")
+        end
+        path = @get_scratch!("project-uuid")
+        @test isdir(path)
+        @test path == scratch_dir(project_uuid, "project-uuid")
+        ## Reset project
+        Base.ACTIVE_PROJECT[] = old_project
     end
 end
 


### PR DESCRIPTION
This makes top-level usage of `@get_scratch!` look in the active project for a UUID to use before falling back to the global namespace.

For a motivating example: Typically when you work on a package you have that package activated. In such a case it is *very* convenient if code running in the REPL behaves similar to how it works inside the package, in particular `@get_scratch!` will now return a path with the package UUID instead of the global namespace:
```
julia> using Scratch

julia> Base.active_project()
"/home/fredrik/dev/Scratch/Project.toml"

julia> @get_scratch!("hello-world")
"/home/fredrik/.julia/scratchspaces/6c6a2e73-6563-6170-7368-637461726353/hello-world"
```

For a package environment without a UUID this patch does not change anything.