### PR TITLE
Change the order of namespace and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Note that we initialize the `download_cache` within `__init__()` so that our pac
 This makes use of the `@get_scratch!()` macro, which is identical to the `get_scratch!()` method, except it automatically determines the UUID of the calling module, if possible. The user can manually pass in a `Module` as well for a slightly more verbose incantation:
 ```julia
 function __init__()
-    global download_cache = get_scratch!("downloaded_files", @__MODULE__)
+    global download_cache = get_scratch!(@__MODULE__, "downloaded_files")
 end
 ```
 

--- a/test/ScratchUsage/src/ScratchUsage.jl
+++ b/test/ScratchUsage/src/ScratchUsage.jl
@@ -14,8 +14,8 @@ const my_version = get_version()
 function touch_scratch()
     # Create an explicitly version-specific space
     private_space = get_scratch!(
-        string(my_version.major, ".", my_version.minor, ".", my_version.patch),
         my_uuid,
+        string(my_version.major, ".", my_version.minor, ".", my_version.patch),
     )
     touch(joinpath(private_space, string("ScratchUsage-", my_version)))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,7 +110,7 @@ end
         other_uuid = Base.UUID("6dc9890c-246d-42f7-b07c-3ce39ca50d56")
         ## Activate test-project from above again
         with_active_project(project) do
-            path = get_scratch!("hello-there", other_uuid, project_uuid)
+            path = get_scratch!(other_uuid, "hello-there", project_uuid)
             ## Test that the path is namespaced to other_uuid, but lifecycled with me
             @test path == scratch_dir(string(other_uuid), "hello-there")
             usage_path = usage_path = Scratch.usage_toml()
@@ -124,7 +124,7 @@ end
         project2 = temp_project_file(other_uuid)
         with_active_project(project) do
             ## This should track project_uuid as the user
-            path = get_scratch!("general-kenobi", project_uuid)
+            path = get_scratch!(project_uuid, "general-kenobi")
             @test project_uuid ∈ first.(keys(Scratch.scratch_access_timers))
             usage = Pkg.TOML.parsefile(usage_path)
             @test any(project ∈ record["parent_projects"] for record in usage[path])
@@ -133,13 +133,13 @@ end
             ## Reaching for the same space as another owner should (i) track this
             ## usage and (ii) write to scratch_usage.toml since this belongs to
             ## another project file
-            path = get_scratch!("general-kenobi", project_uuid, other_uuid)
+            path = get_scratch!(project_uuid, "general-kenobi", other_uuid)
             @test other_uuid ∈ first.(keys(Scratch.scratch_access_timers))
             usage = Pkg.TOML.parsefile(usage_path)
             @test any(project2 ∈ record["parent_projects"] for record in usage[path])
         end
         ## Deleting the path should remove both UUIDs from the timers
-        delete_scratch!("general-kenobi", project_uuid)
+        delete_scratch!(project_uuid, "general-kenobi")
         @test project_uuid ∉ first.(keys(Scratch.scratch_access_timers))
         @test other_uuid ∉ first.(keys(Scratch.scratch_access_timers))
     end


### PR DESCRIPTION
Change the order of namespace and key in `get_scratch!` and `delete_scratch!`. This order is, IMO, more natural and matches the resulting path.