### PR TITLE
track_scratch_access: fix a corner case when trying to look up the project file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Scratch"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
 authors = ["Elliot Saba <staticfloat@gmail.com>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -116,7 +116,9 @@ function track_scratch_access(pkg_uuid::UUID, scratch_path::AbstractString)
         for (p, m) in Base.loaded_modules
             if p.uuid == pkg_uuid
                 source_path = Base.pathof(m)
-                return Base.current_project(dirname(source_path))
+                if source_path !== nothing
+                    return Base.current_project(dirname(source_path))
+                end
             end
         end
 


### PR DESCRIPTION
`track_scratch_access`: fix a corner case when trying to look up the project file for a loaded package that is not reachable any longer and thus `Base.pathof(m)` returns `nothing`.