### PR TITLE
Fix find_uuid

### DIFF
--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -40,7 +40,7 @@ end
 const uuid_re = r"uuid\s*=\s*(?i)\"([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\""
 
 find_uuid(uuid::UUID) = uuid
-find_uuid(mod::Module) = find_uuid(Base.PkgId(parent_pkg).uuid)
+find_uuid(mod::Module) = find_uuid(Base.PkgId(mod).uuid)
 function find_uuid(::Nothing)
     # Try and see if the current project has a UUID
     project = Base.active_project()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,7 @@ end
             path = @get_scratch!("project-no-uuid")
             @test isdir(path)
             @test path == scratch_dir(global_uuid, "project-no-uuid")
+            @test path === get_scratch!(@__MODULE__, "project-no-uuid")
         end
         ## Project.toml with UUID
         project_uuid = Base.UUID("69386cca-e009-4a96-a0ae-829213699cfc")
@@ -102,6 +103,7 @@ end
             path = @get_scratch!("project-uuid")
             @test isdir(path)
             @test path == scratch_dir(string(project_uuid), "project-uuid")
+            @test path === get_scratch!(@__MODULE__, "project-uuid")
         end # do
 
         # Cross-package scratch usage: Test that the scratch space is namespaced


### PR DESCRIPTION
This PR fixes a typo in

https://github.com/JuliaPackaging/Scratch.jl/blob/56771063045708ef8fc01ad8616db9edab06f3a7/src/Scratch.jl#L43

i.e., `parent_pkg` in the rhs should be `mod`.

This code path is tested by verifying the invariance `@get_scratch!(key) == get_scratch!(@__MODULE__, key)`.
