### PR TITLE
README.md: make version_specific_scratch const

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ end
 const pkg_version = get_version()
 
 # This will be filled in by `__init__()`; it might change if we get deployed somewhere
-version_specific_scratch = Ref{String}()
+const version_specific_scratch = Ref{String}()
 
 function __init__()
     # This space will be unique between versions of my package that different major and


### PR DESCRIPTION
I assume the reason why version_specific_scratch is a Ref{String} is so that it can
be made const, for type stability.