### PR TITLE
Widen version compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
   - windows
 julia:
+  - 1.0
   - 1.5
   - nightly
 branches:

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "1.0.3"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
-julia = "1.5"
+julia = "1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -105,7 +105,7 @@ function track_scratch_access(pkg_uuid::UUID, scratch_path::AbstractString)
         # as long as the global environment within the depot itself is intact.
         if pkg_uuid === UUID(UInt128(0))
             p = Base.active_project()
-            if p !== nothing
+            if p !== nothing && isfile(p)
                 return p
             end
             return Base.load_path_expand("@v#.#")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,3 +1,5 @@
+maybe_io(io) = VERSION < v"1.4" ? NamedTuple() : (; io = io)
+
 function temp_pkg_dir(fn::Function; rm=true)
     old_load_path = copy(LOAD_PATH)
     old_depot_path = copy(DEPOT_PATH)
@@ -16,7 +18,7 @@ function temp_pkg_dir(fn::Function; rm=true)
             try
                 push!(LOAD_PATH, "@", "@v#.#", "@stdlib")
                 push!(DEPOT_PATH, depot_dir)
-                Pkg.develop(PackageSpec(path=dirname(@__DIR__)); io=pkgio)
+                Pkg.develop(PackageSpec(path=dirname(@__DIR__)); maybe_io(pkgio)...)
                 fn(env_dir)
             finally
                 try
@@ -73,8 +75,8 @@ function install_test_ScratchUsage(project_path::String, version::VersionNumber)
     write(fpath, replace(read(fpath, String), "99.99.99" => string(version)))
 
     # dev() that path, to add it to the environment, then test it!
-    Pkg.develop(PackageSpec(path=joinpath(project_path, "ScratchUsage")); io=pkgio)
+    Pkg.develop(PackageSpec(path=joinpath(project_path, "ScratchUsage")); maybe_io(pkgio)...)
     redirect_stderr(pkgio) do; redirect_stdout(pkgio) do
-        Pkg.test("ScratchUsage"; io=pkgio)
+        Pkg.test("ScratchUsage"; maybe_io(pkgio)...)
     end end
 end


### PR DESCRIPTION
Fixes #22. It seems all that was needed was to check for existence of `active_project` since it was returning an invalid path for Julia 1.0-1.2, not sure why though. Locally all tests were passing, but we'll see what travis thinks...

Bit of a hack to handle the `io` keyword for Julia below 1.4, alternative suggestions welcome.