### PR TITLE
Make `Scratch` more resistant to `EACCES` errors

### DIFF
--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -137,7 +137,6 @@ function track_scratch_access(pkg_uuid::UUID, scratch_path::AbstractString)
                     if project_path !== nothing
                         return project_path
                     end
-                    continue
                 end
             end
         end

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -37,13 +37,27 @@ function scratch_dir(args...)
     end
 end
 
+function ignore_eacces(f::Function)
+    try
+        return f()
+    catch e
+        if !isa(e, Base.IOError) || e.code != -Base.Libc.EACCES
+            rethrow(e)
+        end
+        return nothing
+    end
+end
+
 const uuid_re = r"uuid\s*=\s*(?i)\"([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\""
 
 find_uuid(uuid::UUID) = uuid
 find_uuid(mod::Module) = find_uuid(Base.PkgId(mod).uuid)
 function find_uuid(::Nothing)
     # Try and see if the current project has a UUID
-    project = Base.active_project()
+    project = ignore_eacces() do
+        Base.active_project()
+    end
+
     if project !== nothing && isfile(project)
         str = read(project, String)
         if (m = match(uuid_re, str); m !== nothing)
@@ -117,7 +131,13 @@ function track_scratch_access(pkg_uuid::UUID, scratch_path::AbstractString)
             if p.uuid == pkg_uuid
                 source_path = Base.pathof(m)
                 if source_path !== nothing
-                    return Base.current_project(dirname(source_path))
+                    project_path = ignore_eacces() do
+                        Base.current_project(dirname(source_path))
+                    end
+                    if project_path !== nothing
+                        return project_path
+                    end
+                    continue
                 end
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,6 +105,13 @@ end
             @test isdir(path)
             @test path == scratch_dir(string(project_uuid), "project-uuid")
             @test path === get_scratch!(@__MODULE__, "project-uuid")
+
+            ## Issue #29; when the Project.toml is not accessible, we should not throw an error
+            if Sys.isunix()
+                chmod(dirname(project), 0o000)
+                Scratch.track_scratch_access(project_uuid, "not a real path")
+                chmod(dirname(project), 0o755)
+            end
         end # do
 
         # Cross-package scratch usage: Test that the scratch space is namespaced


### PR DESCRIPTION
When attempting to look up `Project.toml` files, we must be resilient
against permission denied errors, as we may attempt to look up files in
`/root` or similar, especially if we are baked in as a system image from
a build worker.