### PR TITLE
Add JULIA_TRACK_SCRATCH_ACCESS env variable, to allow disabling tracking of scratch access

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ end
 
 ### Can I disable logging scratch usage?
 
-You can disable logging to `logs/scratch_usage.toml` by setting `JULIA_TRACK_SCRATCH_ACCESS` to `0` in your environment.
+You can disable logging to `logs/scratch_usage.toml` by setting `JULIA_SCRATCH_TRACK_ACCESS` to `0` in your environment.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ function export_scratch(scratch_name::String, github_repo::String)
 end
 ```
 
+### Can I disable logging scratch usage?
+
+You can disable logging to `logs/scratch_usage.toml` by setting `JULIA_TRACK_SCRATCH_ACCESS` to `0` in your environment.
+
 ## Compatibility
 
 The package is tested and works correctly with Julia 1.0 and above. However, Pkg's built-in

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -112,8 +112,8 @@ function track_scratch_access(pkg_uuid::UUID, scratch_path::AbstractString)
         return
     end
 
-    # Do not track scratch access when JULIA_TRACK_SCRATCH_ACCESS=0
-    get(ENV, "JULIA_TRACK_SCRATCH_ACCESS", "1") == "0" && return
+    # Do not track scratch access when JULIA_SCRATCH_TRACK_ACCESS=0
+    get(ENV, "JULIA_SCRATCH_TRACK_ACCESS", "1") == "0" && return
 
     function find_project_file(pkg_uuid::UUID)
         # The simplest case (`pkg_uuid` == UUID(0)) simply attributes the space to

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -112,6 +112,9 @@ function track_scratch_access(pkg_uuid::UUID, scratch_path::AbstractString)
         return
     end
 
+    # Do not track scratch access when JULIA_TRACK_SCRATCH_ACCESS=0
+    get(ENV, "JULIA_TRACK_SCRATCH_ACCESS", "1") == "0" && return
+
     function find_project_file(pkg_uuid::UUID)
         # The simplest case (`pkg_uuid` == UUID(0)) simply attributes the space to
         # the active project, and if that does not exist, the  global depot environment,


### PR DESCRIPTION
Add JULIA_TRACK_SCRATCH_ACCESS env variable, to allow disabling tracking of scratch access. Set to JULIA_TRACK_SCRATCH_ACCESS=0 to disable.

Rationale: we use PackageCompiler.jl to generate a *readonly* build artifact for deployment. PackageCompiler sets the depot path in the created executable, here: https://github.com/JuliaLang/PackageCompiler.jl/blob/master/src/embedding_wrapper.c#L96 When building the package, we make sure the scratchspaces are filled as expected, however, Scratch.jl wants to write a log of the usage, which we do not want. This PR would allow us to disable this logging. We also tried running the PackageCompiler binary with an extended DEPOT_PATH (where the first path in would be writable), however, this will cause the scratchspaces to be created on the first runtime execution, which is not desirable (wrt reproducibility and possible runtime errors, eg. download/network issues ).