### PR TITLE
Add minimal documentation stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,16 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v3
 
-#   Documentation:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#       - uses: julia-actions/setup-julia@latest
-#         with:
-#           version: 1
-#       - uses: julia-actions/cache@v1
-#         with:
-#           cache-registries: "true"
-#       - uses: julia-actions/julia-docdeploy@releases/v1
-#         env:
-#           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+  Documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+      - uses: julia-actions/cache@v1
+        with:
+          cache-registries: "true"
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Manifest.toml
+/docs/build/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Scratch.jl
 
+[![CI](https://github.com/JuliaPackaging/Scratch.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/JuliaPackaging/Scratch.jl/actions/workflows/ci.yml)
+
+[![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliapackaging.github.io/Scratch.jl/stable)
+[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://juliapackaging.github.io/Scratch.jl/dev)
+
+[![codecov](https://codecov.io/gh/JuliaPackaging/Scratch.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaPackaging/Scratch.jl)
+
+
 This repository implements the scratch spaces API for package-specific mutable containers of data.
 These spaces can contain datasets, text, binaries, or any other kind of data that would be convenient to store in a location specific to your package.
 As compared to [Artifacts](https://pkgdocs.julialang.org/v1/artifacts/), these containers of data are mutable.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,11 @@
+using Documenter, Scratch
+
+makedocs(
+    modules = [Scratch],
+    sitename = "Scratch.jl",
+)
+
+deploydocs(
+    repo = "github.com/JuliaPackaging/Scratch.jl.git",
+    push_preview = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,20 @@
+# Scratch.jl Documentation
+
+This is the reference documentation of
+[`Scratch.jl`](https://github.com/JuliaPackaging/Scratch.jl).
+
+## Index
+```@index
+```
+
+## Macros
+```@autodocs
+Modules = [Scratch]
+Order = [:macro]
+```
+
+## Functions
+```@autodocs
+Modules = [Scratch]
+Order = [:function]
+```


### PR DESCRIPTION
This makes progress towards resolving #37. Of course it's not there yet, because the generated docs are missing most of the useful information in the README.md... But at least it is a start.

To make further progress, we could just copy that from the README.md to the manual, but now the same text lives in two places and needs to be kept in sync. Perhaps it would be better to *move* most of the text in the README.md and just retain a link to the manual plus perhaps some quick examples?

Thoughts?