### PR TITLE
Override scratch directory with preference or environmental variable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [compat]
 julia = "1"
+Preferences = "1"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -34,7 +34,7 @@ be overridden via `with_scratch_directory()`.
 """
 function scratch_dir(args...)
     if SCRATCH_DIR_OVERRIDE[] === nothing
-        if VERSION >= v"1.6"
+        @static if VERSION >= v"1.6"
             scratch_base_path = @load_preference("scratch_dir", 
                 get(ENV, "JULIA_SCRATCH_DIR",
                     joinpath(first(Base.DEPOT_PATH), "scratchspaces")

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -2,7 +2,7 @@ module Scratch
 import Base: UUID
 using Dates
 
-@static if VERSION >= v"1.6"
+if VERSION >= v"1.6"
     using Preferences
 end
 

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -2,6 +2,16 @@ module Scratch
 import Base: UUID
 using Dates
 
+@static if VERSION >= v"1.6"
+    using Preferences
+end
+
+@static if VERSION >= v"1.6"
+    const scratch_base_path = @load_preference("scratch_dir", joinpath(first(Base.DEPOT_PATH), "scratchspaces"))
+else
+    const scratch_base_path = joinpath(first(Base.DEPOT_PATH), "scratchspaces")
+end
+
 export with_scratch_directory, scratch_dir, get_scratch!, delete_scratch!, clear_scratchspaces!, @get_scratch!
 
 const SCRATCH_DIR_OVERRIDE = Ref{Union{String,Nothing}}(nothing)
@@ -30,7 +40,7 @@ be overridden via `with_scratch_directory()`.
 """
 function scratch_dir(args...)
     if SCRATCH_DIR_OVERRIDE[] === nothing
-        return abspath(first(Base.DEPOT_PATH), "scratchspaces", args...)
+        return abspath(scratch_base_path, args...)
     else
         # If we've been given an override, use _only_ that directory.
         return abspath(SCRATCH_DIR_OVERRIDE[], args...)

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -6,12 +6,6 @@ using Dates
     using Preferences
 end
 
-@static if VERSION >= v"1.6"
-    const scratch_base_path = @load_preference("scratch_dir", joinpath(first(Base.DEPOT_PATH), "scratchspaces"))
-else
-    const scratch_base_path = joinpath(first(Base.DEPOT_PATH), "scratchspaces")
-end
-
 export with_scratch_directory, scratch_dir, get_scratch!, delete_scratch!, clear_scratchspaces!, @get_scratch!
 
 const SCRATCH_DIR_OVERRIDE = Ref{Union{String,Nothing}}(nothing)
@@ -40,6 +34,17 @@ be overridden via `with_scratch_directory()`.
 """
 function scratch_dir(args...)
     if SCRATCH_DIR_OVERRIDE[] === nothing
+        if VERSION >= v"1.6"
+            scratch_base_path = @load_preference("scratch_dir", 
+                get(ENV, "JULIA_SCRATCH_DIR",
+                    joinpath(first(Base.DEPOT_PATH), "scratchspaces")
+                )
+            )
+        else
+            scratch_base_path = get(ENV, "JULIA_SCRATCH_DIR",
+                joinpath(first(Base.DEPOT_PATH), "scratchspaces")
+            )
+        end
         return abspath(scratch_base_path, args...)
     else
         # If we've been given an override, use _only_ that directory.


### PR DESCRIPTION
Pursuant to a discussion on Slack, this PR adds the ability to specify an alternate location for scratch directories using `Preferences.jl` or using an environmental variable. My personal reason for needing this is that for large files on HPC, I typically want to put stuff on filesystems that are specifically meant for scratch data / fast access, which is often a different 
filesystem than `$HOME`

Possible sources of bikeshedding:

- Is it ok to take on `Preferences` as a dependency? If not, I still think this would be useful with just the environmental variable option (I couldn't think of a way to do this with a conditional dependency, but I'm happy to take suggestions there).
- The names of the preference / env variable. I currently have `"scratch_dir"` and `JULIA_SCRATCH_DIR` respectively, but don't feel strongly.

Obviously happy  to take any other comments / suggestions, but if this approach is amenable, I can start working on docs and tests.