### PR TITLE
Fix a JET warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,9 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 julia = "1"
 
 [extras]
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Pkg"]
+test = ["JET", "Test", "Pkg"]

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -29,11 +29,12 @@ Returns a path within the current depot's `scratchspaces` directory.  This locat
 be overridden via `with_scratch_directory()`.
 """
 function scratch_dir(args...)
-    if SCRATCH_DIR_OVERRIDE[] === nothing
+    override = SCRATCH_DIR_OVERRIDE[]
+    if override === nothing
         return abspath(first(Base.DEPOT_PATH), "scratchspaces", args...)
     else
         # If we've been given an override, use _only_ that directory.
-        return abspath(SCRATCH_DIR_OVERRIDE[], args...)
+        return abspath(override, args...)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,3 +204,11 @@ if VERSION >= v"1.6.0-DEV.676"
         end
     end
 end
+
+@static if Base.VERSION >= v"1.7
+    using JET
+
+    @testset "test_package" begin
+        test_package("Scratch")
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,7 +205,7 @@ if VERSION >= v"1.6.0-DEV.676"
     end
 end
 
-@static if Base.VERSION >= v"1.7
+if Base.VERSION >= v"1.7"
     using JET
 
     @testset "test_package" begin


### PR DESCRIPTION
In the 'else' path, JET cannot prove that SCRATCH_DIR_OVERRIDE[] is
(still) 'nothing', and thus reports a possible error. This then is also
shown when analyzing packages that use Scratch. This can be resolved by
assigning it first to a temporary variable.
