### PR TITLE
Run CI tests against 1.10-beta, too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         julia-version:
           - "1.0"
           - "1"
+          - '~1.10.0-0'
           - "nightly"
         os:
           - ubuntu-latest
@@ -25,7 +26,7 @@ jobs:
         julia-arch:
           - x64
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
@@ -39,7 +40,7 @@ jobs:
   Documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1


### PR DESCRIPTION
The Julia nightly tests are broken, and I worry that there might also be problems with 1.10 that are currently invisible to us