### PR TITLE
README typo: global ref[] = ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ function __init__()
     # This space will be unique between versions of my package that different major and
     # minor versions, but allows patch releases to share the same.
     scratch_name = "data_for_version-$(pkg_version.major).$(pkg_version.minor)"
-    global version_specific_scratch[] = @get_scratch!(scratch_name)
+    version_specific_scratch[] = @get_scratch!(scratch_name)
 end
 
 end # module


### PR DESCRIPTION
Hey! Scratch is cool!

Little typo fix in the README: a ref change does not need the `global` keyword