### PR TITLE
Add OnceInitScratch for concurrency-safe initialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "Scratch"
 uuid = "6c6a2e73-6563-6170-7368-637461726353"
-authors = ["Elliot Saba <staticfloat@gmail.com>"]
 version = "1.3.0"
+authors = ["Elliot Saba <staticfloat@gmail.com>"]
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FileWatching = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [compat]
+FileWatching = "1.9.0"
 julia = "1.9"
 
 [extras]

--- a/src/Scratch.jl
+++ b/src/Scratch.jl
@@ -1,8 +1,10 @@
 module Scratch
 import Base: UUID
 using Dates
+using FileWatching
+using FileWatching.Pidfile
 
-export with_scratch_directory, scratch_dir, get_scratch!, delete_scratch!, clear_scratchspaces!, @get_scratch!
+export with_scratch_directory, scratch_dir, get_scratch!, delete_scratch!, clear_scratchspaces!, @get_scratch!, OnceInitScratch, @OnceInitScratch
 
 const SCRATCH_DIR_OVERRIDE = Ref{Union{String,Nothing}}(nothing)
 """
@@ -204,6 +206,15 @@ function prune_timers!(path)
     return nothing
 end
 
+function validate_key(key)
+    # Verify that the key is valid (only needed here at construction time)
+    if match(r"^[a-zA-Z0-9-\._]+$", key) === nothing
+        throw(ArgumentError(
+            "invalid key \"$key\": keys may only include a-z, A-Z, 0-9, -, _, and ."
+            ))
+    end
+end
+
 """
     get_scratch!(parent_pkg = nothing, key::AbstractString, calling_pkg = parent_pkg)
 
@@ -232,12 +243,7 @@ function get_scratch!(parent_pkg::Union{Module,UUID,Nothing}, key::AbstractStrin
                       depot_path::String = first(Base.DEPOT_PATH),
                       time_gate::TimePeriod = Hour(24),
                       curr_time::DateTime = Dates.now())
-    # Verify that the key is valid (only needed here at construction time)
-    if match(r"^[a-zA-Z0-9-\._]+$", key) === nothing
-        throw(ArgumentError(
-            "invalid key \"$key\": keys may only include a-z, A-Z, 0-9, -, _, and ."
-            ))
-    end
+    validate_key(key)
     parent_pkg = find_uuid(parent_pkg)
     calling_pkg = find_uuid(calling_pkg)
     # Calculate the path and create the containing folder
@@ -313,6 +319,66 @@ macro get_scratch!(key)
     uuid = Base.PkgId(__module__).uuid
     return quote
         get_scratch!($(esc(uuid)), $(esc(key)), $(esc(uuid)))
+    end
+end
+
+struct OnceInitScratch{F}
+    init::F
+    parent_pkg::UUID
+    key::String
+    calling_pkg::UUID
+    function OnceInitScratch(init::F,
+                                 parent_pkg::Union{Module,UUID,Nothing},
+                                 key::AbstractString,
+                                 calling_pkg::Union{Module,UUID,Nothing} = parent_pkg) where {F}
+        parent_pkg = find_uuid(parent_pkg)
+        calling_pkg = find_uuid(calling_pkg)
+        validate_key(key)
+        return new{F}(init, parent_pkg, String(key), calling_pkg)
+    end
+end
+
+function (ops::OnceInitScratch)(; depot_path::String = first(Base.DEPOT_PATH),
+                      time_gate::TimePeriod = Hour(24),
+                      curr_time::DateTime = Dates.now())
+    path = scratch_path(ops.parent_pkg, ops.key; depot_path)
+    ispath(path) && return path
+
+    mkpath(dirname(path))
+    mkpidlock(string(path, ".lock")) do
+        # Re-check path within lock
+        ispath(path) && return
+
+        # Create a temporary directory in the same path
+        tempdir = mktempdir(dirname(path))
+        ops.init(tempdir)
+
+        # Atomically move the directory to the final location - after this point other
+        # users may start using the directory. The lock only prevents multiple
+        # initializations from racing each other.
+        mv(tempdir, path)
+        Base.Filesystem.temp_cleanup_forget(tempdir)
+    end
+
+    # Go through the ordinary path to unify access tracking
+    ret = get_scratch!(ops.parent_pkg, ops.key, ops.calling_pkg;
+                       depot_path=depot_path,
+                       time_gate=time_gate,
+                       curr_time=curr_time)
+    @assert ret == path
+    return path
+end
+
+macro OnceInitScratch(args...)
+    uuid = Base.PkgId(__module__).uuid
+    if length(args) == 1
+        key = args[1]
+        return :(OnceInitScratch($(esc(uuid)), $(esc(key)), $(esc(uuid))))
+    elseif length(args) == 2
+        f, key = args
+        return :(OnceInitScratch($(esc(f)), $(esc(uuid)), $(esc(key)), $(esc(uuid))))
+    else
+        error("@OnceInitScratch takes either 1 or 2 arguments")
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,6 +229,41 @@ end
     end
 end
 
+@testset "OnceInitScratch" begin
+    mktempdir() do depot_path
+        # Test basic once init
+        did_run = false
+        local temp_dir
+        ois = @OnceInitScratch("ois_foo") do dir
+            temp_dir = dir
+            @test isdir(temp_dir)
+            did_run = true
+        end
+        path = ois(; depot_path)
+        @test path != temp_dir
+        @test isdir(path)
+        @test !isdir(temp_dir)
+        @test did_run
+        did_run = false
+        path2 = ois(; depot_path)
+        @test path == path2
+        @test !did_run
+
+        # Test that a second OnceInitScratch works the same
+        ois2 = @OnceInitScratch("ois_foo") do _
+            did_run = true
+        end
+        path3 = ois2(; depot_path)
+        @test path == path3
+        @test !did_run
+
+        # Test that removing the scratch space allows it to run again
+        rm(path; force=true, recursive=true)
+        path4 = ois2(; depot_path)
+        @test path == path4
+        @test did_run
+    end
+end
 
 # Run a test using JET to do some static analysis for us
 if Base.VERSION >= v"1.10"


### PR DESCRIPTION
This adds OnceInitScractch for safe concurrent initialization of scratchspaces. A common use for scratchspaces is to set up a directory, fill it with some files, and then hand it off to some external process. If the initialization is not made concurrency-safe, this can cause problems (either by providing the directory to the external process to early or by trying an initialization twice that may not be idempotent). This provides an opt-in concurrency safe interface that pidlocks the initial creation of the scratch-space until after a provided initializer has run. It is superficially similar to https://github.com/JuliaLang/julia/pull/59002, but keyed on scratchspaces and does not try to ensure that the initializer is the same for all instances - doing this correctly is up to the user. It simply provides mutual exclusion for the running initializers.